### PR TITLE
Exclude challenge path

### DIFF
--- a/haproxy.conf
+++ b/haproxy.conf
@@ -21,7 +21,7 @@ frontend www
 
   acl accepted sc_get_gpt(1,0) gt 0
   http-request return status 200 content-type "text/html; charset=UTF-8" hdr "Cache-control" "max-age=0, no-cache" lf-file /etc/haproxy/challenge.html if protected !challenge_path !accepted
-  use_backend challenge if { path /_challenge }
+  use_backend challenge if challenge_path
 
 # This should not need changing except the name of the stick table to use
 # (matches the frontend name by default).

--- a/haproxy.conf
+++ b/haproxy.conf
@@ -12,6 +12,7 @@ frontend www
   http-request normalize-uri path-strip-dot
   http-request normalize-uri path-strip-dotdot
 
+  acl challenge_path path /_challenge
   # Adjust these to the paths you want to protect.
   acl protected_path path -m reg /(some-expensive/thing|another/).*
   # Matches the default config of anubis of triggering on "Mozilla"
@@ -19,7 +20,7 @@ frontend www
   acl protected acl(protected_path,protected_ua)
 
   acl accepted sc_get_gpt(1,0) gt 0
-  http-request return status 200 content-type "text/html; charset=UTF-8" hdr "Cache-control" "max-age=0, no-cache" lf-file /etc/haproxy/challenge.html if protected !accepted
+  http-request return status 200 content-type "text/html; charset=UTF-8" hdr "Cache-control" "max-age=0, no-cache" lf-file /etc/haproxy/challenge.html if protected !challenge_path !accepted
   use_backend challenge if { path /_challenge }
 
 # This should not need changing except the name of the stick table to use


### PR DESCRIPTION
Exclude challenge path from the match that may be captured by the protected path regex.

This way `/_challenge` always falls through to the `use_backend` challenge directive, regardless of how broad `protected_path` regex is, so then `path -m reg /.*` can be used safely.

Closes #5, tested. Maybe also closes #4.