### PR TITLE
Move difficulty to a variable

### DIFF
--- a/challenge.html
+++ b/challenge.html
@@ -19,7 +19,7 @@ SPDX-License-Identifier: 0BSD
 <form method="post" target="post" action="/_challenge" name="challenge">
   <input type="hidden" name="ip" value="%[src]">
   <input type="hidden" name="ts" value="%[date]">
-  <input type="hidden" name="diff" value="4">
+  <input type="hidden" name="diff" value="%[var(txn.diff)]">
   <input type="hidden" name="tries" value="">
 </form>
 <div id="progress"><span id="progressText"></span><div id="progressBar"></div></div>

--- a/haproxy.conf
+++ b/haproxy.conf
@@ -20,6 +20,8 @@ frontend www
   acl protected acl(protected_path,protected_ua)
 
   acl accepted sc_get_gpt(1,0) gt 0
+  # Set difficulty
+  http-request set-var(txn.diff) int(4)
   http-request return status 200 content-type "text/html; charset=UTF-8" hdr "Cache-control" "max-age=0, no-cache" lf-file /etc/haproxy/challenge.html if protected !challenge_path !accepted
   use_backend challenge if challenge_path
 
@@ -36,8 +38,7 @@ backend challenge
   http-request set-var(txn.host) hdr(Host),host_only
   http-request set-var(txn.hash) src,concat(;,txn.host,),concat(;,txn.ts,),concat(;,txn.tries),sha2,hex
   acl ts_recent date,neg,add(txn.ts) ge -60
-  # 4 is the difficulty, should match "diff" in challenge.html.
-  acl hash_good var(txn.hash) -m reg 0{4}.*
+  acl hash_good var(txn.hash),ltrim(0),length,add(txn.diff) -m int le 64
   http-request sc-set-gpt(1,0) 1 if challenge_req ts_recent hash_good
   http-request return status 200 if challenge_req hash_good
   http-request return status 400 content-type "text/html; charset=UTF-8" hdr "Cache-control" "max-age=0" string "Bad request" if !challenge_req OR !hash_good


### PR DESCRIPTION
Move difficulty to a variable that can be defined once and then used in the template and backend check.

The backend check changes to as follows:

1. Strip leading zeros.
2. Get remaining length.
3. Add difficulty.
4. Compare with 64 (SHA256 hex is always 64 chars). If true, then the number of zeros is at least as set.

I'm not sure about performance of var initialization in HAProxy, but simple operations like these (even if it's 5 of them) should be faster than calling a regex library, so I don't think it'll have a significant hit.

While convenience is great, it also opens the door to adaptive difficulty. Combined with a bit of extra smart logic and HMAC, it could be dynamic based on other signals, such as rate limiting, headers, JA3[N] fingerprinting, whitelists, etc.